### PR TITLE
Lua 5.2 to 5.4 support

### DIFF
--- a/base58-dev-1.rockspec
+++ b/base58-dev-1.rockspec
@@ -1,5 +1,5 @@
 package = "base58"
-version = "dev-1"
+version = "dev-2"
 
 source = {
   url = "git://github.com/leafo/lua-base58.git",
@@ -12,7 +12,7 @@ description = {
 }
 
 dependencies = {
-  "lua ~> 5.1"
+  "lua >= 5.1, <= 5.4"
 }
 
 build = {

--- a/base58/init.lua
+++ b/base58/init.lua
@@ -15,8 +15,10 @@ do
   end
   alphabet_char_to_i = _tbl_0
 end
+local unpack = table.unpack or unpack
 local BigInt
 do
+  local _class_0
   local _base_0 = {
     is_zero = function(self)
       local _list_0 = self.bytes
@@ -83,7 +85,7 @@ do
     end
   }
   _base_0.__index = _base_0
-  local _class_0 = setmetatable({
+  _class_0 = setmetatable({
     __init = function(self, bytes)
       if bytes == nil then
         bytes = { }

--- a/base58/init.moon
+++ b/base58/init.moon
@@ -3,6 +3,8 @@ alphabet = "rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"
 alphabet_i_to_char = { i, alphabet\sub(i,i) for i=1,#alphabet }
 alphabet_char_to_i = { alphabet\sub(i,i), i for i=1,#alphabet }
 
+unpack = table.unpack or unpack
+
 -- TODO: null byte in string seems to break things
 
 -- represents number as array of bytes (unpacked string)


### PR DESCRIPTION
Needed to use this with Lua 5.4; the only thing preventing this from working with Lua 5.2+ was `unpack` being renamed to `table.unpack`, specs succeed on Lua5.1/5.2/5.3/5.4 now.
Thanks for the module!